### PR TITLE
Add check for invalid UTF-8 chars in userinfo

### DIFF
--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -856,6 +856,12 @@ qboolean Info_IsValid(const char *s)
 		return false;
 	};
 
+	// invalid utf8 chars are deprecated
+	if (!Q_UnicodeValidate(s))
+	{
+		return FALSE;
+	}
+
 	while (*s == '\\')
 	{
 		const char* key = ++s;


### PR DESCRIPTION
More info: https://github.com/rehlds/ReHLDS/pull/1074

My footage with svc_disconnect message which demonstrates the issue (should be fixed in PR):

https://github.com/user-attachments/assets/f8d509a8-cdd2-48c1-832d-8133d791b317

Works on HL Co-op server too.